### PR TITLE
add : 챌린지 기능 추가

### DIFF
--- a/src/main/java/com/fizz/fizz_server/FizzApplication.java
+++ b/src/main/java/com/fizz/fizz_server/FizzApplication.java
@@ -2,7 +2,10 @@ package com.fizz.fizz_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+
+@EnableScheduling // 스케줄러 활성화
 @SpringBootApplication
 public class FizzApplication {
 

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/api/ChallengeController.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/api/ChallengeController.java
@@ -1,6 +1,7 @@
 package com.fizz.fizz_server.domain.challenge.api;
 
 
+import com.fizz.fizz_server.domain.challenge.dto.request.ChallengeInfoRequestDto;
 import com.fizz.fizz_server.domain.challenge.dto.request.CreateChallengeRequestDto;
 import com.fizz.fizz_server.domain.challenge.dto.response.ChallengeInfoResponseDto;
 import com.fizz.fizz_server.domain.challenge.dto.response.ChallengeSummaryResponseDto;
@@ -14,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,10 +27,8 @@ public class ChallengeController {
 
     private final ChallengeService challengeService;
 
-
     // UserPrincipal 추후 추가되면 삭제 예정
     private final UserRepository userRepository;
-
 
 
     //챌린지 생성
@@ -42,37 +40,55 @@ public class ChallengeController {
         return ResponseEntity.status(HttpStatus.CREATED) .body(ResponseUtil.createSuccessResponse());
     }
 
-    //챌린지 상세정보
+    //id 기반 챌린지 상세정보 조회
     @GetMapping("/info/{challengeId}")
     public ResponseEntity<ResponseBody<ChallengeInfoResponseDto>> getChallengeInfoByChallengeId(@PathVariable Long challengeId ){
         ChallengeInfoResponseDto responseDto = challengeService.getChallengeInfoByChallengeId(challengeId);
         return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( responseDto ));
     }
 
+    //챌린지명(title) 기반 챌린지 상세정보 조회
+    @GetMapping("/info")
+    public ResponseEntity<ResponseBody<ChallengeInfoResponseDto>> getChallengeInfoByChallengeTitle(@Valid @RequestBody ChallengeInfoRequestDto requestDto){
+        ChallengeInfoResponseDto responseDto = challengeService.getChallengeInfoByChallengeTitle(requestDto.getTitle());
+        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( responseDto ));
+    }
+
     //모든 잠든 챌린지 목록
     @GetMapping("/sleep")
     public ResponseEntity<ResponseBody<List<ChallengeSummaryResponseDto>>> getSleepingChallengeList(){
-        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( null ));
+        List<ChallengeSummaryResponseDto> responseDtos = challengeService.getSleepingChallengeList();
+        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( responseDtos ));
     }
-
 
     //모든 활성화 상태 챌린지 목록
     @GetMapping
     public ResponseEntity<ResponseBody<List<ChallengeSummaryResponseDto>>> getActiveChallengeList(){
-        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( null ));
-    }
-
-
-    //특정 카테고리의 활성화 상태 챌린지 목록
-    @GetMapping("/{categoryId}")
-    public ResponseEntity<ResponseBody<List<ChallengeSummaryResponseDto>>> getActiveChallengeListByCategoryId(){
-        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( null ));
+        List<ChallengeSummaryResponseDto> responseDtos = challengeService.getActiveChallengeList();
+        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( responseDtos ));
     }
 
     //특정 카테고리의 잠든 상태 챌린지 목록
     @GetMapping("/sleep/{categoryId}")
-    public ResponseEntity<ResponseBody<List<ChallengeSummaryResponseDto>>> getSleepingChallengeListByCategoryId(){
-        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( null ));
+    public ResponseEntity<ResponseBody<List<ChallengeSummaryResponseDto>>> getSleepingChallengeListByCategoryId(@PathVariable Long categoryId){
+        List<ChallengeSummaryResponseDto> responseDtos = challengeService.getSleepingChallengeListByCategoryId(categoryId);
+        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( responseDtos ));
+    }
+
+    //특정 카테고리의 활성화 상태 챌린지 목록
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<ResponseBody<List<ChallengeSummaryResponseDto>>> getActiveChallengeListByCategoryId(@PathVariable Long categoryId){
+        List<ChallengeSummaryResponseDto> responseDtos = challengeService.getActiveChallengeListByCategoryId(categoryId);
+        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( responseDtos ));
+    }
+
+    //해당 사용자가 생성한 활성화 상태 챌린지 목록
+    @GetMapping("/sleep/user")
+    public ResponseEntity<ResponseBody<List<ChallengeSummaryResponseDto>>> getSleepingChallengeListByUser( ){// parameter 에 @AuthenticationPrincipal UserPrincipal user 추후 추가
+        User tempUser = userRepository.findById(1L).get();
+
+        List<ChallengeSummaryResponseDto> responseDtos = challengeService.getSleepingChallengeListByUser(tempUser);
+        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( responseDtos ));
     }
 
     //해당 사용자가 생성한 활성화 상태 챌린지 목록
@@ -80,17 +96,8 @@ public class ChallengeController {
     public ResponseEntity<ResponseBody<List<ChallengeSummaryResponseDto>>> getActiveChallengeListByUser( ){// parameter 에 @AuthenticationPrincipal UserPrincipal user 추후 추가
         User tempUser = userRepository.findById(1L).get();
 
-
-        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( null ));
-    }
-
-
-    //해당 사용자가 생성한 활성화 상태 챌린지 목록
-    @GetMapping("/sleep/user")
-    public ResponseEntity<ResponseBody<List<ChallengeSummaryResponseDto>>> getSleepingChallengeListByUser( ){// parameter 에 @AuthenticationPrincipal UserPrincipal user 추후 추가
-        User tempUser = userRepository.findById(1L).get();
-
-        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( null ));
+        List<ChallengeSummaryResponseDto> responseDtos = challengeService.getActiveChallengeListByUser(tempUser);
+        return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse( responseDtos ));
     }
 
 }

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/domain/Challenge.java
@@ -23,15 +23,11 @@ public class Challenge extends BaseEntity {
     @Column(name = "challenge_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String title;
 
     @Column(nullable = false)
     private String description;
-
-    @Column(nullable = false,name = "start_date")
-    private LocalDateTime startDate;
-
 
     @JoinColumn(name = "category_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
@@ -47,12 +43,15 @@ public class Challenge extends BaseEntity {
     @OneToMany(mappedBy = "challenge")
     private List<Participant> participants = new ArrayList<>();
 
+    @Column(nullable = false)
+    private boolean isActive;
+
     @Builder
-    public Challenge(User creator, Category category, String description, LocalDateTime startDate, String title) {
+    public Challenge(User creator, Category category, String description, boolean isActive,String title) {
         this.creator = creator;
         this.category = category;
         this.description = description;
-        this.startDate = startDate;
+        this.isActive=isActive;
         this.title = title;
     }
 }

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/dto/request/ChallengeInfoRequestDto.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/dto/request/ChallengeInfoRequestDto.java
@@ -1,0 +1,19 @@
+package com.fizz.fizz_server.domain.challenge.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ChallengeInfoRequestDto {
+
+        @NotBlank(message = "title은 빈값일 수 없습니다.")
+        private String title;
+
+
+}

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/dto/request/CreateChallengeRequestDto.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/dto/request/CreateChallengeRequestDto.java
@@ -1,6 +1,6 @@
 package com.fizz.fizz_server.domain.challenge.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fizz.fizz_server.domain.category.domain.Category;
 import com.fizz.fizz_server.domain.challenge.domain.Challenge;
 import com.fizz.fizz_server.domain.user.domain.User;
@@ -12,7 +12,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
 
 @Setter
 @NoArgsConstructor
@@ -30,17 +29,17 @@ public class CreateChallengeRequestDto {
     @NotBlank(message = "description은 빈값일 수 없습니다.")
     private String description;
 
-    @NotNull(message = "startDate는 빈값일 수 없습니다.")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime startDate;
+    @JsonProperty("isActive")
+    private boolean isActive;
+
 
     public Challenge toChallenge(User creator, Category category){
         return Challenge.builder()
                 .creator(creator)
                 .category(category)
                 .description(this.description)
+                .isActive(this.isActive)
                 .title(this.title)
-                .startDate(this.startDate)
                 .build();
     }
 

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/dto/response/ChallengeInfoResponseDto.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/dto/response/ChallengeInfoResponseDto.java
@@ -18,17 +18,19 @@ public class ChallengeInfoResponseDto {
     private Long userId;
     private String title;
     private String description;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime startDate;
+    private Boolean isActive;
+    private Integer participantCounts;
 
-    public static ChallengeInfoResponseDto EntityToDTO(Challenge challenge){
+
+    public static ChallengeInfoResponseDto toDTO(Challenge challenge, Integer participantCounts){
         ChallengeInfoResponseDto dto =  new ChallengeInfoResponseDto();
         dto.challengeId =challenge.getId();
         dto.categoryId =challenge.getCategory().getCategoryId();
         dto.userId=challenge.getCreator().getId();
         dto.title=challenge.getTitle();
         dto.description = challenge.getDescription();
-        dto.startDate=challenge.getStartDate();
+        dto.isActive =challenge.isActive();
+        dto.participantCounts = participantCounts;
         return dto;
     }
 

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/dto/response/ChallengeSummaryResponseDto.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/dto/response/ChallengeSummaryResponseDto.java
@@ -1,10 +1,9 @@
 package com.fizz.fizz_server.domain.challenge.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.fizz.fizz_server.domain.challenge.domain.Challenge;
+import lombok.*;
 
+@ToString
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -14,7 +13,17 @@ public class ChallengeSummaryResponseDto {
         private Long challengeId;
         private Long categoryId;
         private String title;
-        private Long participantCounts;
+        private Integer participantCounts;
+
+
+        public static ChallengeSummaryResponseDto toDTO(Challenge challenge, Integer participantCounts){
+                ChallengeSummaryResponseDto dto = new ChallengeSummaryResponseDto();
+                dto.challengeId =challenge.getId();
+                dto.categoryId =challenge.getCategory().getCategoryId();
+                dto.title=challenge.getTitle();
+                dto.participantCounts = participantCounts;
+                return dto;
+        }
 
 
 }

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/repository/ChallengeRepository.java
@@ -1,14 +1,40 @@
 package com.fizz.fizz_server.domain.challenge.repository;
 
+import com.fizz.fizz_server.domain.category.domain.Category;
 import com.fizz.fizz_server.domain.challenge.domain.Challenge;
+import com.fizz.fizz_server.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+    Optional<Challenge> findByTitle(String title);
+
+    @Modifying
+    @Query("UPDATE Challenge c SET c.isActive = false WHERE c.isActive = true AND c.createdAt <= :period")
+    Integer changeStateToSleeping(LocalDateTime period);
+
+    List<Challenge> findByIsActiveTrue();
+
+    List<Challenge> findByIsActiveFalse();
+
+    @Query("SELECT c FROM Challenge c WHERE c.category = :category AND c.isActive = true")
+    List<Challenge> findByCategoryAndIsActiveTrue(Category category);
+
+    @Query("SELECT c FROM Challenge c WHERE c.category = :category AND c.isActive = false")
+    List<Challenge> findByCategoryAndIsActiveFalse(Category category);
+
+    @Query("SELECT c FROM Challenge c WHERE c.creator = :user AND c.isActive = true")
+    List<Challenge> findByCreatorAndIsActiveTrue(User user);
+
+    @Query("SELECT c FROM Challenge c WHERE c.creator = :user AND c.isActive = false")
+    List<Challenge> findByCreatorAndIsActiveFalse(User user);
+
 }

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/repository/ParticipantRepository.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/repository/ParticipantRepository.java
@@ -1,0 +1,15 @@
+package com.fizz.fizz_server.domain.challenge.repository;
+
+import com.fizz.fizz_server.domain.challenge.domain.Challenge;
+import com.fizz.fizz_server.domain.challenge.domain.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface ParticipantRepository  extends JpaRepository<Participant, Long> {
+
+    @Query("SELECT COUNT(p) FROM Participant p WHERE p.challenge = :challenge")
+    Integer countByChallenge(Challenge challenge);
+}

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/scheduler/ChallengeScheduler.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/scheduler/ChallengeScheduler.java
@@ -1,0 +1,22 @@
+package com.fizz.fizz_server.domain.challenge.scheduler;
+
+
+import com.fizz.fizz_server.domain.challenge.service.ChallengeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ChallengeScheduler {
+
+    private final ChallengeService challengeService;
+
+    @Scheduled(cron = "${challenge.schedule.cron}")
+    public void changeStateToSleeping(){
+        Integer updatedRowCount = challengeService.changeStateToSleeping();
+        log.info("changeStateToSleeping method excuted, updated {} rows",updatedRowCount);
+    }
+}

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/service/ChallengeService.java
@@ -9,8 +9,14 @@ public interface ChallengeService {
     //챌린지 생성
     public void createChallengeByCategoryId(User user , CreateChallengeRequestDto requestDto);
 
-    //챌린지 상세정보
+    //id 기반 챌린지 상세정보 조회
     public ChallengeInfoResponseDto getChallengeInfoByChallengeId( Long challengeId );
+
+    //챌린지명 기반 챌린지 상세정보 조회
+    public ChallengeInfoResponseDto getChallengeInfoByChallengeTitle( String challengeTitle );
+
+    //챌린지를 잠든 상태로 전환
+    public Integer changeStateToSleeping();
 
     //모든 잠든 챌린지 목록
     public List<ChallengeSummaryResponseDto> getSleepingChallengeList();
@@ -19,14 +25,14 @@ public interface ChallengeService {
     public List<ChallengeSummaryResponseDto> getActiveChallengeList();
 
     //특정 카테고리의 활성화 상태 챌린지 목록
-    public List<ChallengeSummaryResponseDto> getActiveChallengeListByCategoryId();
+    public List<ChallengeSummaryResponseDto> getActiveChallengeListByCategoryId(Long categoryId);
 
     //특정 카테고리의 잠든 상태 챌린지 목록
-    public List<ChallengeSummaryResponseDto> getSleepingChallengeListByCategoryId();
+    public List<ChallengeSummaryResponseDto> getSleepingChallengeListByCategoryId(Long categoryId);
 
     //해당 사용자가 생성한 활성화 상태 챌린지 목록
-    public List<ChallengeSummaryResponseDto> getActiveChallengeListByUser( Long userId );
+    public List<ChallengeSummaryResponseDto> getActiveChallengeListByUser( User user );
 
     //해당 사용자가 생성한 활성화 상태 챌린지 목록
-    public List<ChallengeSummaryResponseDto> getSleepingChallengeListByUser( Long userId );
+    public List<ChallengeSummaryResponseDto> getSleepingChallengeListByUser( User user );
 }

--- a/src/main/java/com/fizz/fizz_server/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/service/ChallengeServiceImpl.java
@@ -7,14 +7,19 @@ import com.fizz.fizz_server.domain.challenge.dto.request.CreateChallengeRequestD
 import com.fizz.fizz_server.domain.challenge.dto.response.ChallengeInfoResponseDto;
 import com.fizz.fizz_server.domain.challenge.dto.response.ChallengeSummaryResponseDto;
 import com.fizz.fizz_server.domain.challenge.repository.ChallengeRepository;
+import com.fizz.fizz_server.domain.challenge.repository.ParticipantRepository;
 import com.fizz.fizz_server.domain.user.domain.User;
+import com.fizz.fizz_server.domain.user.repository.UserRepository;
 import com.fizz.fizz_server.global.base.response.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.fizz.fizz_server.global.base.response.exception.ExceptionType.NON_EXISTENT_CATEGORY_ERROR;
 import static com.fizz.fizz_server.global.base.response.exception.ExceptionType.NON_EXISTENT_CHALLENGE_ERROR;
@@ -24,9 +29,13 @@ import static com.fizz.fizz_server.global.base.response.exception.ExceptionType.
 @RequiredArgsConstructor
 @Service
 public class ChallengeServiceImpl implements ChallengeService{
-
    private final ChallengeRepository challengeRepository;
    private final CategoryRepository categoryRepository;
+   private final ParticipantRepository participantRepository;
+   private final UserRepository userRepository;
+
+    @Value("${challenge.period.months}")
+    private int period;
 
     @Transactional
     @Override
@@ -40,40 +49,85 @@ public class ChallengeServiceImpl implements ChallengeService{
     @Override
     public ChallengeInfoResponseDto getChallengeInfoByChallengeId(Long challengeId) {
         Challenge challenge = challengeRepository.findById(challengeId).orElseThrow(()->new BusinessException(NON_EXISTENT_CHALLENGE_ERROR));
-        ChallengeInfoResponseDto responseDto = ChallengeInfoResponseDto.EntityToDTO(challenge);
+        Integer participantCounts = participantRepository.countByChallenge(challenge);
+        ChallengeInfoResponseDto responseDto = ChallengeInfoResponseDto.toDTO(challenge,participantCounts);
         log.info(responseDto.toString());
         return responseDto;
     }
 
     @Override
+    public ChallengeInfoResponseDto getChallengeInfoByChallengeTitle(String challengeTitle) {
+        Challenge challenge = challengeRepository.findByTitle(challengeTitle).orElseThrow(()->new BusinessException(NON_EXISTENT_CHALLENGE_ERROR));
+        Integer participantCounts = participantRepository.countByChallenge(challenge);
+        ChallengeInfoResponseDto responseDto = ChallengeInfoResponseDto.toDTO(challenge,participantCounts);
+        log.info(responseDto.toString());
+        return responseDto;
+    }
+
+    @Transactional
+    @Override
+    public Integer changeStateToSleeping() {
+        LocalDateTime period = LocalDateTime.now().minusMonths(this.period);
+        Integer updated = challengeRepository.changeStateToSleeping(period);
+        return updated;
+    }
+
+    @Override
     public List<ChallengeSummaryResponseDto> getSleepingChallengeList()  {
-        return List.of();
+        List<Challenge> entityList = challengeRepository.findByIsActiveFalse();
+        List<ChallengeSummaryResponseDto> dtoList = entityListToDtoList(entityList);
+        log.info(dtoList.toString());
+        return dtoList;
     }
 
     @Override
     public List<ChallengeSummaryResponseDto> getActiveChallengeList()  {
-        return List.of();
-    }
-    @Override
-    public List<ChallengeSummaryResponseDto> getActiveChallengeListByCategoryId() {
-        return List.of();
-    }
-
-    @Override
-    public List<ChallengeSummaryResponseDto> getActiveChallengeListByUser(Long userId) {
-        return List.of();
+        List<Challenge> entityList = challengeRepository.findByIsActiveTrue();
+        List<ChallengeSummaryResponseDto> dtoList = entityListToDtoList(entityList);
+        log.info(dtoList.toString());
+        return dtoList;
     }
 
     @Override
-    public List<ChallengeSummaryResponseDto> getSleepingChallengeListByCategoryId() {
-        return List.of();
+    public List<ChallengeSummaryResponseDto> getSleepingChallengeListByCategoryId(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId).orElseThrow(()->new BusinessException(NON_EXISTENT_CATEGORY_ERROR));
+        List<Challenge> entityList = challengeRepository.findByCategoryAndIsActiveFalse(category);
+        List<ChallengeSummaryResponseDto> dtoList = entityListToDtoList(entityList);
+        log.info(dtoList.toString());
+        return dtoList;
     }
 
     @Override
-    public List<ChallengeSummaryResponseDto> getSleepingChallengeListByUser(Long userId) {
-        return List.of();
+    public List<ChallengeSummaryResponseDto> getActiveChallengeListByCategoryId(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId).orElseThrow(()->new BusinessException(NON_EXISTENT_CATEGORY_ERROR));
+        List<Challenge> entityList = challengeRepository.findByCategoryAndIsActiveTrue(category);
+        List<ChallengeSummaryResponseDto> dtoList = entityListToDtoList(entityList);
+        log.info(dtoList.toString());
+        return dtoList;
     }
 
+    @Override
+    public List<ChallengeSummaryResponseDto> getSleepingChallengeListByUser( User user ) {
+        List<Challenge> entityList = challengeRepository.findByCreatorAndIsActiveFalse(user);
+        List<ChallengeSummaryResponseDto> dtoList = entityListToDtoList(entityList);
+        log.info(dtoList.toString());
+        return dtoList;
+    }
 
+    @Override
+    public List<ChallengeSummaryResponseDto> getActiveChallengeListByUser( User user ) {
+        List<Challenge> entityList = challengeRepository.findByCreatorAndIsActiveTrue(user);
+        List<ChallengeSummaryResponseDto> dtoList = entityListToDtoList(entityList);
+        log.info(dtoList.toString());
+        return dtoList;
+    }
+
+    public List<ChallengeSummaryResponseDto> entityListToDtoList(List<Challenge> entityList){
+        List<ChallengeSummaryResponseDto> dtoList
+                = entityList.stream().
+                map(entity-> ChallengeSummaryResponseDto.toDTO(entity, participantRepository.countByChallenge(entity)))
+                .collect(Collectors.toList());
+        return dtoList;
+    }
 
 }

--- a/src/main/java/com/fizz/fizz_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/fizz/fizz_server/global/config/SecurityConfig.java
@@ -37,13 +37,14 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/**").permitAll()
                         .anyRequest().hasRole("ADMIN"))
-                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .oauth2Login(configure ->
-                        configure.authorizationEndpoint(config -> config.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository))
-                                .userInfoEndpoint(config -> config.userService(customOAuth2UserService))
-                                .successHandler(oAuth2AuthenticationSuccessHandler)
-                                .failureHandler(oAuth2AuthenticationFailureHandler))
-                .addFilterBefore(new JwtAuthorizationFilter(tokenProvider, authenticationManager), UsernamePasswordAuthenticationFilter.class);
+//                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+//                .oauth2Login(configure ->
+//                        configure.authorizationEndpoint(config -> config.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository))
+//                                .userInfoEndpoint(config -> config.userService(customOAuth2UserService))
+//                                .successHandler(oAuth2AuthenticationSuccessHandler)
+//                                .failureHandler(oAuth2AuthenticationFailureHandler))
+//                .addFilterBefore(new JwtAuthorizationFilter(tokenProvider, authenticationManager), UsernamePasswordAuthenticationFilter.class)
+        ;
 
         return http.build();
     }


### PR DESCRIPTION
## 📌 필독
- application.properties 에 다음을 추가하여 사용 
```
challenge.schedule.cron=0 0 0 * * ?
challenge.period.months=6
```

## ✨ PR 세부 내용
-  challenge 테이블에 isActive 컬럼을 도입해 활성화 상태와 잠든 상태 구분
- 챌린지의 활성화 상태와 잠든 상태의 구별 및 그에 따른 처리(getSleepingChallengeList, getActiveChallengeList, getActiveChallengeListByCategoryId, getActiveChallengeListByUser, getSleepingChallengeListByCategoryId, getSleepingChallengeListByUser) : 시작일로부터 6개월 이상 경과 시 isActive 컬럼을 스프링부트 스케줄러를 활용하여 자동으로 false 로 수정되게 함
    - 매일 12시 자정(cron=0 0 0 * * ?) 에 업데이트 쿼리 날림
- 챌린지 검색 기능 : 챌린지명(title)기반으로 검색되게 구현
-  챌린지의 startDate 컬럼 삭제
- 챌린지의 title 컬럼에 unique 제약 조건 추가

## ✅ ToDo
- userPrincipal 반영하여 코드작성

