### PR TITLE
fix : 프론트 요청 따른 댓글 구현부 수정2

### DIFF
--- a/src/main/java/com/fizz/fizz_server/domain/comment/dto/response/CommentInfoWithChildCountResponseDto.java
+++ b/src/main/java/com/fizz/fizz_server/domain/comment/dto/response/CommentInfoWithChildCountResponseDto.java
@@ -3,6 +3,8 @@ package com.fizz.fizz_server.domain.comment.dto.response;
 import com.fizz.fizz_server.domain.comment.domain.Comment;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @ToString
 @Setter
 @NoArgsConstructor
@@ -16,8 +18,11 @@ public class CommentInfoWithChildCountResponseDto {
     private String content;
     private Integer likeCount;
     private Long childCount;
+    private String nickname;
+    private LocalDateTime createdAt;
 
-    public static CommentInfoWithChildCountResponseDto toDTO(Comment comment, Long childCount){
+
+    public static CommentInfoWithChildCountResponseDto toDTO(Comment comment, Long childCount ){
         CommentInfoWithChildCountResponseDto dto = new CommentInfoWithChildCountResponseDto();
         dto.commentId = comment.getId();
         if(comment.getParent() != null ) dto.parentId = comment.getParent().getId();
@@ -25,6 +30,8 @@ public class CommentInfoWithChildCountResponseDto {
         dto.content = comment.getContent();
         dto.likeCount = comment.getCommentLikes().size();
         dto.childCount = childCount;
+        dto.nickname = comment.getUser().getNickname();
+        dto.createdAt = comment.getCreatedAt();
         return dto;
     }
 }

--- a/src/main/java/com/fizz/fizz_server/domain/comment/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/fizz/fizz_server/domain/comment/repository/CustomCommentRepositoryImpl.java
@@ -21,7 +21,9 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
                 "c.user.id, " +
                 "c.content, " +
                 "SIZE(c.commentLikes), " +
-                "COUNT(child)) " +
+                "COUNT(child), " +
+                "c.user.nickname, " +
+                "c.createdAt) " +
                 "FROM Comment c LEFT JOIN c.children child " +
                 "WHERE c.post = :post AND c.parent IS NULL " +
                 "GROUP BY c";


### PR DESCRIPTION
## ✨ PR 세부 내용
- Comment 단의 부모 댓글 목록 반환 시 댓글 user의 nickname과 댓글 작성 시간 정보도 함께 반환하도록 수정