### PR TITLE
fix : 게시글 삭제 시 참여자 삭제 로직 수정

### DIFF
--- a/src/main/java/com/fizz/fizz_server/domain/challenge/repository/ParticipantRepository.java
+++ b/src/main/java/com/fizz/fizz_server/domain/challenge/repository/ParticipantRepository.java
@@ -4,7 +4,9 @@ import com.fizz.fizz_server.domain.challenge.domain.Challenge;
 import com.fizz.fizz_server.domain.challenge.domain.Participant;
 import com.fizz.fizz_server.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -20,6 +22,6 @@ public interface ParticipantRepository  extends JpaRepository<Participant, Long>
     @Query("SELECT p.challenge FROM Participant p WHERE p.user = :user")
     List<Challenge> findByUser(User user);
 
-    List<Participant> findByUserAndChallenge(User user, Challenge challenge);
+    Optional<Participant> findFirstByUserAndChallenge(User user, Challenge challenge);
 
 }

--- a/src/main/java/com/fizz/fizz_server/domain/post/service/PostService.java
+++ b/src/main/java/com/fizz/fizz_server/domain/post/service/PostService.java
@@ -12,14 +12,12 @@ import com.fizz.fizz_server.domain.post.dto.response.PostInfo;
 import com.fizz.fizz_server.domain.post.repository.PostLikeRepository;
 import com.fizz.fizz_server.domain.post.repository.PostRepository;
 import com.fizz.fizz_server.domain.post.repository.ViewRepository;
-import com.fizz.fizz_server.domain.user.domain.CustomUserPrincipal;
 import com.fizz.fizz_server.domain.user.domain.User;
 import com.fizz.fizz_server.domain.user.repository.UserRepository;
 import com.fizz.fizz_server.global.base.response.exception.BusinessException;
 import com.fizz.fizz_server.global.base.response.exception.ExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -111,9 +109,9 @@ public class PostService {
             throw new BusinessException(ExceptionType.POST_USER_NOT_MATCHED);
         }
 
-        List<Participant> participants = participantRepository.findByUserAndChallenge(post.getUser(), post.getChallenge());
-        participantRepository.deleteAll(participants);
-        
+        Participant participant = participantRepository.findFirstByUserAndChallenge(post.getUser(), post.getChallenge())
+                .orElseThrow(() -> new BusinessException(PARTICIPANT_NOT_FOUND));
+        participantRepository.delete(participant);
         postRepository.delete(post);
     }
 

--- a/src/main/java/com/fizz/fizz_server/global/base/response/exception/ExceptionType.java
+++ b/src/main/java/com/fizz/fizz_server/global/base/response/exception/ExceptionType.java
@@ -47,8 +47,10 @@ public enum ExceptionType {
     FILE_TOO_LARGE(PAYLOAD_TOO_LARGE, "F004", "파일 크기가 너무 큼."),
 
     // comment
-    NON_EXISTENT_COMMENT_ERROR(BAD_REQUEST,"C007","존재하지 않는 댓글")
+    NON_EXISTENT_COMMENT_ERROR(BAD_REQUEST,"C007","존재하지 않는 댓글"),
 
+    // participant
+    PARTICIPANT_NOT_FOUND(NOT_FOUND, "P001", "참여자가 존재하지 않음."),
     ;
 
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] add : ~
-->

## ✨ PR 세부 내용
- 모든 참여자 삭제 -> 참여자 1명만 삭제
- DB 구조상 참여자-사용자 쌍으로만 이루어져 있어서 한 사용자가 챌린지에 여러번 참여하게 되면 같은 필드가 쌓이게 되어 limit 옵션으로 한 개만 가져와서 삭제하게 수정했습니다.
<!-- 수정/추가한 내용을 적어주세요. -->
