### PR TITLE
fix : oauth2에서 받아온 이메일을 필수 요소가 아니도록 변경

### DIFF
--- a/src/main/java/com/fizz/fizz_server/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/fizz/fizz_server/global/oauth2/service/CustomOAuth2UserService.java
@@ -1,6 +1,5 @@
 package com.fizz.fizz_server.global.oauth2.service;
 
-import com.fizz.fizz_server.global.oauth2.exception.OAuth2AuthenticationProcessingException;
 import com.fizz.fizz_server.global.oauth2.user.info.OAuth2UserInfo;
 import com.fizz.fizz_server.global.oauth2.user.info.OAuth2UserInfoFatory;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +10,6 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -34,10 +32,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String accessToken = userRequest.getAccessToken().getTokenValue();
 
         OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFatory.getOAuth2UserInfo(registrationId, accessToken, oAuth2User.getAttributes());
-
-        if (!StringUtils.hasText(oAuth2UserInfo.getEmail())) {
-            throw new OAuth2AuthenticationProcessingException("Email not found from OAuth2 Provider");
-        }
 
         return new OAuth2UserPrincipal(oAuth2UserInfo);
     }

--- a/src/main/java/com/fizz/fizz_server/global/oauth2/service/OAuth2UserPrincipal.java
+++ b/src/main/java/com/fizz/fizz_server/global/oauth2/service/OAuth2UserPrincipal.java
@@ -24,7 +24,7 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
 
     @Override
     public String getUsername() {
-        return userInfo.getEmail();
+        return userInfo.getId();
     }
 
     @Override
@@ -59,7 +59,7 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
 
     @Override
     public String getName() {
-        return userInfo.getEmail();
+        return userInfo.getId();
     }
 
     public OAuth2UserInfo getUserInfo() {


### PR DESCRIPTION

## ✨ PR 세부 내용
- 네이버 검수 요청을 위해 최소한의 내용만 받기 위해 이메일이 필수가 아니도록 Oauth2 로직 수정
